### PR TITLE
Clear cache on logout

### DIFF
--- a/es/FetchProvider.js
+++ b/es/FetchProvider.js
@@ -2,8 +2,8 @@ function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try
 
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
-import React, { useContext } from 'react';
-import { Provider } from 'use-http';
+import React, { useContext, useEffect } from 'react';
+import { useFetch, Provider } from 'use-http';
 import { Context as ConfigContext } from './ConfigContext';
 import { Context as CurrentUserContext } from './account/CurrentUserContext';
 
@@ -65,7 +65,36 @@ function FetchProvider(_ref) {
   return /*#__PURE__*/React.createElement(Provider, {
     options: options,
     url: apiRootUrl
-  }, children);
+  }, /*#__PURE__*/React.createElement(CacheClearer, null), children);
+}
+
+export function useClearCache() {
+  var _useFetch = useFetch({
+    persist: false
+  }),
+      memoryCache = _useFetch.cache;
+
+  var _useFetch2 = useFetch({
+    persist: true,
+    cachePolicy: 'cache-first'
+  }),
+      storageCache = _useFetch2.cache;
+
+  return function () {
+    memoryCache.clear();
+    storageCache.clear();
+  };
+} // This is a separate component than FetchProvider so that it is rendered
+// inside of `use-http`'s `Provider`.
+
+function CacheClearer() {
+  var clearCache = useClearCache();
+  useEffect(function () {
+    window.addEventListener('signout', function () {
+      clearCache();
+    });
+  }, []);
+  return null;
 }
 
 export default FetchProvider;

--- a/es/index.js
+++ b/es/index.js
@@ -12,6 +12,7 @@ export { default as AuthenticatedRoute } from './AuthenticatedRoute';
 export { default as BrandBar } from './BrandBar';
 export { default as ConfirmedActionButton } from './ConfirmedActionButton';
 export { default as FetchProvider } from './FetchProvider';
+export * from './FetchProvider';
 export { default as Footer } from './Footer';
 export { default as FullscreenButton } from './FullscreenButton';
 export { default as Spinner } from './Spinner';

--- a/lib/FetchProvider.js
+++ b/lib/FetchProvider.js
@@ -5,6 +5,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "functi
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.useClearCache = useClearCache;
 exports["default"] = void 0;
 
 var _react = _interopRequireWildcard(require("react"));
@@ -81,7 +82,37 @@ function FetchProvider(_ref) {
   return /*#__PURE__*/_react["default"].createElement(_useHttp.Provider, {
     options: options,
     url: apiRootUrl
-  }, children);
+  }, /*#__PURE__*/_react["default"].createElement(CacheClearer, null), children);
+}
+
+function useClearCache() {
+  var _useFetch = (0, _useHttp.useFetch)({
+    persist: false
+  }),
+      memoryCache = _useFetch.cache;
+
+  var _useFetch2 = (0, _useHttp.useFetch)({
+    persist: true,
+    cachePolicy: 'cache-first'
+  }),
+      storageCache = _useFetch2.cache;
+
+  return function () {
+    memoryCache.clear();
+    storageCache.clear();
+  };
+} // This is a separate component than FetchProvider so that it is rendered
+// inside of `use-http`'s `Provider`.
+
+
+function CacheClearer() {
+  var clearCache = useClearCache();
+  (0, _react.useEffect)(function () {
+    window.addEventListener('signout', function () {
+      clearCache();
+    });
+  }, []);
+  return null;
 }
 
 var _default = FetchProvider;

--- a/lib/index.js
+++ b/lib/index.js
@@ -199,7 +199,19 @@ var _BrandBar = _interopRequireDefault(require("./BrandBar"));
 
 var _ConfirmedActionButton = _interopRequireDefault(require("./ConfirmedActionButton"));
 
-var _FetchProvider = _interopRequireDefault(require("./FetchProvider"));
+var _FetchProvider = _interopRequireWildcard(require("./FetchProvider"));
+
+Object.keys(_FetchProvider).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
+  if (key in exports && exports[key] === _FetchProvider[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function get() {
+      return _FetchProvider[key];
+    }
+  });
+});
 
 var _Footer = _interopRequireDefault(require("./Footer"));
 

--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
     "eslint-plugin-react-hooks": "^4.0.8",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "use-http": "^1.0.16"
+    "use-http": "^1.0.21"
   },
   "peerDependencies": {
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "use-http": "^1.0.16"
+    "use-http": "^1.0.21"
   },
   "dependencies": {
     "classnames": "^2.2.6",

--- a/src/FetchProvider.js
+++ b/src/FetchProvider.js
@@ -1,5 +1,5 @@
-import React, { useContext } from 'react';
-import { Provider } from 'use-http';
+import React, { useContext, useEffect } from 'react';
+import { useFetch, Provider } from 'use-http';
 
 import { Context as ConfigContext } from './ConfigContext';
 import { Context as CurrentUserContext } from './account/CurrentUserContext';
@@ -32,10 +32,35 @@ function FetchProvider({ children, cachePolicy }) {
       options={options}
       url={apiRootUrl}
     >
+      <CacheClearer />
       {children}
     </Provider>
   );
 }
 
+
+export function useClearCache() {
+  const { cache: memoryCache } = useFetch({ persist: false });
+  const { cache: storageCache } = useFetch({ persist: true, cachePolicy: 'cache-first' });
+
+  return function() {
+    memoryCache.clear();
+    storageCache.clear();
+  };
+}
+
+// This is a separate component than FetchProvider so that it is rendered
+// inside of `use-http`'s `Provider`.
+function CacheClearer() {
+  const clearCache = useClearCache();
+
+  useEffect(() => {
+    window.addEventListener('signout', () => {
+      clearCache();
+    });
+  }, []);
+
+  return null;
+}
 
 export default FetchProvider;

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ export { default as AuthenticatedRoute } from './AuthenticatedRoute';
 export { default as BrandBar } from './BrandBar';
 export { default as ConfirmedActionButton } from './ConfirmedActionButton';
 export { default as FetchProvider } from './FetchProvider';
+export * from './FetchProvider';
 export { default as Footer } from './Footer';
 export { default as FullscreenButton } from './FullscreenButton';
 export { default as Spinner } from './Spinner';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3290,21 +3290,21 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
 
-urs@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/urs/-/urs-0.0.7.tgz#2dbf320a68a54bbd67ab9c5ac103b0f2227ca6be"
+urs@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/urs/-/urs-0.0.8.tgz#8a0e0b792073cdb7eec926d08ab1e017ffab3f66"
 
 use-http@^1.0.16:
-  version "1.0.16"
-  resolved "https://registry.yarnpkg.com/use-http/-/use-http-1.0.16.tgz#6d75f3e734abf990049c7a02b22d757c3abda883"
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/use-http/-/use-http-1.0.21.tgz#e2c3c83becf9c7afceed95e33f52b85f61993c61"
   dependencies:
-    urs "^0.0.7"
-    use-ssr "^1.0.22"
+    urs "^0.0.8"
+    use-ssr "^1.0.24"
     utility-types "^3.10.0"
 
-use-ssr@^1.0.22:
-  version "1.0.23"
-  resolved "https://registry.yarnpkg.com/use-ssr/-/use-ssr-1.0.23.tgz#3bde1e10cd01b3b61ab6386d7cddb72e74828bf8"
+use-ssr@^1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/use-ssr/-/use-ssr-1.0.24.tgz#213a3df58f5ab9268e6fe1a57ad0a9de91e514d1"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
This PR adds support for clearing the `use-http` cache when the user logs out.  The cache is cleared indiscriminately.