### PR TITLE
Add custom account menu items passed in from webapp

### DIFF
--- a/es/BrandBar.js
+++ b/es/BrandBar.js
@@ -19,7 +19,7 @@ import { useData } from './BrandingContext';
 export default function BrandBar(_ref) {
   var className = _ref.className,
       navItems = _ref.navItems,
-      loginItems = _ref.loginItems;
+      accountMenuItems = _ref.accountMenuItems;
   return /*#__PURE__*/React.createElement("nav", {
     className: classNames('navbar navbar-expand-lg navbar-light bg-white', className)
   }, /*#__PURE__*/React.createElement("a", {
@@ -32,7 +32,7 @@ export default function BrandBar(_ref) {
   }, /*#__PURE__*/React.createElement(BrandbarHomeNav, null), /*#__PURE__*/React.createElement(BrandBarItems, null), navItems), /*#__PURE__*/React.createElement("ul", {
     className: "navbar-nav"
   }, /*#__PURE__*/React.createElement(AccountMenu, {
-    items: loginItems
+    items: accountMenuItems
   }))));
 }
 

--- a/es/BrandBar.js
+++ b/es/BrandBar.js
@@ -18,7 +18,8 @@ import { BrandbarLogo, BrandbarHomeNav } from './Branding';
 import { useData } from './BrandingContext';
 export default function BrandBar(_ref) {
   var className = _ref.className,
-      navItems = _ref.navItems;
+      navItems = _ref.navItems,
+      loginItems = _ref.loginItems;
   return /*#__PURE__*/React.createElement("nav", {
     className: classNames('navbar navbar-expand-lg navbar-light bg-white', className)
   }, /*#__PURE__*/React.createElement("a", {
@@ -30,7 +31,9 @@ export default function BrandBar(_ref) {
     className: "navbar-nav"
   }, /*#__PURE__*/React.createElement(BrandbarHomeNav, null), /*#__PURE__*/React.createElement(BrandBarItems, null), navItems), /*#__PURE__*/React.createElement("ul", {
     className: "navbar-nav"
-  }, /*#__PURE__*/React.createElement(AccountMenu, null))));
+  }, /*#__PURE__*/React.createElement(AccountMenu, {
+    items: loginItems
+  }))));
 }
 
 function BrandBarItems(_ref2) {

--- a/es/account/Menu.js
+++ b/es/account/Menu.js
@@ -15,7 +15,9 @@ import { Context as CurrentUserContext } from './CurrentUserContext';
 import SignInModal from './SignInModal';
 import SignedIn from './SignedIn';
 import SignedOut from './SignedOut';
-export default function AccountMenu() {
+export default function AccountMenu(_ref) {
+  var items = _ref.items;
+
   var _useContext = useContext(CurrentUserContext),
       currentUser = _useContext.currentUser;
 
@@ -24,6 +26,7 @@ export default function AccountMenu() {
       showSignInModal = _useState2[0],
       setShowSignInModal = _useState2[1];
 
+  var signedInItems = typeof items === 'undefined' ? [] : items.signedIn;
   var modals = /*#__PURE__*/React.createElement(SignInModal, {
     isOpen: showSignInModal,
     toggle: function toggle() {
@@ -33,7 +36,8 @@ export default function AccountMenu() {
 
   if (currentUser) {
     return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(SignedIn, {
-      currentUser: currentUser
+      currentUser: currentUser,
+      items: signedInItems
     }), modals);
   }
 

--- a/es/account/Menu.js
+++ b/es/account/Menu.js
@@ -26,7 +26,7 @@ export default function AccountMenu(_ref) {
       showSignInModal = _useState2[0],
       setShowSignInModal = _useState2[1];
 
-  var signedInItems = typeof items === 'undefined' ? [] : items.signedIn;
+  var signedInItems = items == null || items.signedIn == null ? [] : items.signedIn;
   var modals = /*#__PURE__*/React.createElement(SignInModal, {
     isOpen: showSignInModal,
     toggle: function toggle() {

--- a/es/account/SignedIn.js
+++ b/es/account/SignedIn.js
@@ -1,5 +1,3 @@
-function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
-
 function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
@@ -13,7 +11,6 @@ function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 import jsGravatar from 'js-gravatar';
 import { Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
@@ -75,11 +72,7 @@ function SignedIn(_ref) {
   }, /*#__PURE__*/React.createElement("img", {
     alt: "Gravatar",
     src: avatarUrl
-  }))), /*#__PURE__*/React.createElement(DropdownMenu, null, signedInLinks.map(function (link) {
-    return /*#__PURE__*/React.createElement(RoutedLink, _extends({
-      key: link.href
-    }, link));
-  }), /*#__PURE__*/React.createElement(DropdownItem, {
+  }))), /*#__PURE__*/React.createElement(DropdownMenu, null, signedInLinks, /*#__PURE__*/React.createElement(DropdownItem, {
     className: "nav nav-link dropdown-item",
     onClick: signOut,
     style: {
@@ -87,15 +80,6 @@ function SignedIn(_ref) {
     },
     tag: "a"
   }, "Log out")));
-}
-
-function RoutedLink(_ref2) {
-  var href = _ref2.href,
-      text = _ref2.text;
-  return /*#__PURE__*/React.createElement(Link, {
-    to: href,
-    className: "nav nav-link dropdown-item"
-  }, text);
 }
 
 export default SignedIn;

--- a/es/account/SignedIn.js
+++ b/es/account/SignedIn.js
@@ -22,10 +22,10 @@ var styles = {
   "userBlock": "styles-module__userBlock___Xd39U"
 };
 import { useSignOut } from './actions';
-var signedInLinks = [];
 
 function SignedIn(_ref) {
-  var currentUser = _ref.currentUser;
+  var currentUser = _ref.currentUser,
+      items = _ref.items;
 
   var _useState = useState(false),
       _useState2 = _slicedToArray(_useState, 2),
@@ -40,6 +40,7 @@ function SignedIn(_ref) {
     });
   };
 
+  var signedInLinks = items;
   var avatarUrl = currentUser.avatarUrl;
 
   if (avatarUrl == null) {

--- a/es/account/SignedIn.js
+++ b/es/account/SignedIn.js
@@ -13,6 +13,7 @@ function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 import jsGravatar from 'js-gravatar';
 import { Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
@@ -75,7 +76,7 @@ function SignedIn(_ref) {
     alt: "Gravatar",
     src: avatarUrl
   }))), /*#__PURE__*/React.createElement(DropdownMenu, null, signedInLinks.map(function (link) {
-    return /*#__PURE__*/React.createElement(Link, _extends({
+    return /*#__PURE__*/React.createElement(RoutedLink, _extends({
       key: link.href
     }, link));
   }), /*#__PURE__*/React.createElement(DropdownItem, {
@@ -88,12 +89,12 @@ function SignedIn(_ref) {
   }, "Log out")));
 }
 
-function Link(_ref2) {
+function RoutedLink(_ref2) {
   var href = _ref2.href,
       text = _ref2.text;
-  return /*#__PURE__*/React.createElement(DropdownItem, {
-    href: href,
-    className: "nav nav-link"
+  return /*#__PURE__*/React.createElement(Link, {
+    to: href,
+    className: "nav nav-link dropdown-item"
   }, text);
 }
 

--- a/es/index.js
+++ b/es/index.js
@@ -24,3 +24,4 @@ export { default as UnauthorizedError } from './UnauthorizedError';
 export { default as useEventListener } from './useEventListener'; // Export a subset of the account modules.
 
 export { Context as CurrentUserContext, Provider as CurrentUserProvider } from './account/CurrentUserContext';
+export { default as AccountMenu } from './account/Menu';

--- a/lib/BrandBar.js
+++ b/lib/BrandBar.js
@@ -34,7 +34,7 @@ function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 function BrandBar(_ref) {
   var className = _ref.className,
       navItems = _ref.navItems,
-      loginItems = _ref.loginItems;
+      accountMenuItems = _ref.accountMenuItems;
   return /*#__PURE__*/_react["default"].createElement("nav", {
     className: (0, _classnames["default"])('navbar navbar-expand-lg navbar-light bg-white', className)
   }, /*#__PURE__*/_react["default"].createElement("a", {
@@ -47,7 +47,7 @@ function BrandBar(_ref) {
   }, /*#__PURE__*/_react["default"].createElement(_Branding.BrandbarHomeNav, null), /*#__PURE__*/_react["default"].createElement(BrandBarItems, null), navItems), /*#__PURE__*/_react["default"].createElement("ul", {
     className: "navbar-nav"
   }, /*#__PURE__*/_react["default"].createElement(_Menu["default"], {
-    items: loginItems
+    items: accountMenuItems
   }))));
 }
 

--- a/lib/BrandBar.js
+++ b/lib/BrandBar.js
@@ -33,7 +33,8 @@ function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 function BrandBar(_ref) {
   var className = _ref.className,
-      navItems = _ref.navItems;
+      navItems = _ref.navItems,
+      loginItems = _ref.loginItems;
   return /*#__PURE__*/_react["default"].createElement("nav", {
     className: (0, _classnames["default"])('navbar navbar-expand-lg navbar-light bg-white', className)
   }, /*#__PURE__*/_react["default"].createElement("a", {
@@ -45,7 +46,9 @@ function BrandBar(_ref) {
     className: "navbar-nav"
   }, /*#__PURE__*/_react["default"].createElement(_Branding.BrandbarHomeNav, null), /*#__PURE__*/_react["default"].createElement(BrandBarItems, null), navItems), /*#__PURE__*/_react["default"].createElement("ul", {
     className: "navbar-nav"
-  }, /*#__PURE__*/_react["default"].createElement(_Menu["default"], null))));
+  }, /*#__PURE__*/_react["default"].createElement(_Menu["default"], {
+    items: loginItems
+  }))));
 }
 
 function BrandBarItems(_ref2) {

--- a/lib/account/Menu.js
+++ b/lib/account/Menu.js
@@ -46,7 +46,7 @@ function AccountMenu(_ref) {
       showSignInModal = _useState2[0],
       setShowSignInModal = _useState2[1];
 
-  var signedInItems = typeof items === 'undefined' ? [] : items.signedIn;
+  var signedInItems = items == null || items.signedIn == null ? [] : items.signedIn;
 
   var modals = /*#__PURE__*/_react["default"].createElement(_SignInModal["default"], {
     isOpen: showSignInModal,

--- a/lib/account/Menu.js
+++ b/lib/account/Menu.js
@@ -35,7 +35,9 @@ function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
-function AccountMenu() {
+function AccountMenu(_ref) {
+  var items = _ref.items;
+
   var _useContext = (0, _react.useContext)(_CurrentUserContext.Context),
       currentUser = _useContext.currentUser;
 
@@ -43,6 +45,8 @@ function AccountMenu() {
       _useState2 = _slicedToArray(_useState, 2),
       showSignInModal = _useState2[0],
       setShowSignInModal = _useState2[1];
+
+  var signedInItems = typeof items === 'undefined' ? [] : items.signedIn;
 
   var modals = /*#__PURE__*/_react["default"].createElement(_SignInModal["default"], {
     isOpen: showSignInModal,
@@ -53,7 +57,8 @@ function AccountMenu() {
 
   if (currentUser) {
     return /*#__PURE__*/_react["default"].createElement(_react["default"].Fragment, null, /*#__PURE__*/_react["default"].createElement(_SignedIn["default"], {
-      currentUser: currentUser
+      currentUser: currentUser,
+      items: signedInItems
     }), modals);
   }
 

--- a/lib/account/SignedIn.js
+++ b/lib/account/SignedIn.js
@@ -9,6 +9,8 @@ exports["default"] = void 0;
 
 var _react = _interopRequireWildcard(require("react"));
 
+var _reactRouterDom = require("react-router-dom");
+
 var _classnames = _interopRequireDefault(require("classnames"));
 
 var _jsGravatar = _interopRequireDefault(require("js-gravatar"));
@@ -95,7 +97,7 @@ function SignedIn(_ref) {
     alt: "Gravatar",
     src: avatarUrl
   }))), /*#__PURE__*/_react["default"].createElement(_reactstrap.DropdownMenu, null, signedInLinks.map(function (link) {
-    return /*#__PURE__*/_react["default"].createElement(Link, _extends({
+    return /*#__PURE__*/_react["default"].createElement(RoutedLink, _extends({
       key: link.href
     }, link));
   }), /*#__PURE__*/_react["default"].createElement(_reactstrap.DropdownItem, {
@@ -108,12 +110,12 @@ function SignedIn(_ref) {
   }, "Log out")));
 }
 
-function Link(_ref2) {
+function RoutedLink(_ref2) {
   var href = _ref2.href,
       text = _ref2.text;
-  return /*#__PURE__*/_react["default"].createElement(_reactstrap.DropdownItem, {
-    href: href,
-    className: "nav nav-link"
+  return /*#__PURE__*/_react["default"].createElement(_reactRouterDom.Link, {
+    to: href,
+    className: "nav nav-link dropdown-item"
   }, text);
 }
 

--- a/lib/account/SignedIn.js
+++ b/lib/account/SignedIn.js
@@ -42,10 +42,10 @@ var styles = {
   "inlineButton": "styles-module__inlineButton___2jwhT",
   "userBlock": "styles-module__userBlock___Xd39U"
 };
-var signedInLinks = [];
 
 function SignedIn(_ref) {
-  var currentUser = _ref.currentUser;
+  var currentUser = _ref.currentUser,
+      items = _ref.items;
 
   var _useState = (0, _react.useState)(false),
       _useState2 = _slicedToArray(_useState, 2),
@@ -60,6 +60,7 @@ function SignedIn(_ref) {
     });
   };
 
+  var signedInLinks = items;
   var avatarUrl = currentUser.avatarUrl;
 
   if (avatarUrl == null) {

--- a/lib/account/SignedIn.js
+++ b/lib/account/SignedIn.js
@@ -9,8 +9,6 @@ exports["default"] = void 0;
 
 var _react = _interopRequireWildcard(require("react"));
 
-var _reactRouterDom = require("react-router-dom");
-
 var _classnames = _interopRequireDefault(require("classnames"));
 
 var _jsGravatar = _interopRequireDefault(require("js-gravatar"));
@@ -24,8 +22,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "d
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
-
-function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
 function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
 
@@ -96,11 +92,7 @@ function SignedIn(_ref) {
   }, /*#__PURE__*/_react["default"].createElement("img", {
     alt: "Gravatar",
     src: avatarUrl
-  }))), /*#__PURE__*/_react["default"].createElement(_reactstrap.DropdownMenu, null, signedInLinks.map(function (link) {
-    return /*#__PURE__*/_react["default"].createElement(RoutedLink, _extends({
-      key: link.href
-    }, link));
-  }), /*#__PURE__*/_react["default"].createElement(_reactstrap.DropdownItem, {
+  }))), /*#__PURE__*/_react["default"].createElement(_reactstrap.DropdownMenu, null, signedInLinks, /*#__PURE__*/_react["default"].createElement(_reactstrap.DropdownItem, {
     className: "nav nav-link dropdown-item",
     onClick: signOut,
     style: {
@@ -108,15 +100,6 @@ function SignedIn(_ref) {
     },
     tag: "a"
   }, "Log out")));
-}
-
-function RoutedLink(_ref2) {
-  var href = _ref2.href,
-      text = _ref2.text;
-  return /*#__PURE__*/_react["default"].createElement(_reactRouterDom.Link, {
-    to: href,
-    className: "nav nav-link dropdown-item"
-  }, text);
 }
 
 var _default = SignedIn;

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,8 @@ var _exportNames = {
   UnauthorizedError: true,
   useEventListener: true,
   CurrentUserContext: true,
-  CurrentUserProvider: true
+  CurrentUserProvider: true,
+  AccountMenu: true
 };
 Object.defineProperty(exports, "ErrorBoundary", {
   enumerable: true,
@@ -132,6 +133,12 @@ Object.defineProperty(exports, "CurrentUserProvider", {
   enumerable: true,
   get: function get() {
     return _CurrentUserContext.Provider;
+  }
+});
+Object.defineProperty(exports, "AccountMenu", {
+  enumerable: true,
+  get: function get() {
+    return _Menu["default"];
   }
 });
 exports.utils = void 0;
@@ -263,6 +270,8 @@ var _UnauthorizedError = _interopRequireDefault(require("./UnauthorizedError"));
 var _useEventListener = _interopRequireDefault(require("./useEventListener"));
 
 var _CurrentUserContext = require("./account/CurrentUserContext");
+
+var _Menu = _interopRequireDefault(require("./account/Menu"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 

--- a/src/BrandBar.js
+++ b/src/BrandBar.js
@@ -6,7 +6,7 @@ import AccountMenu from './account/Menu';
 import { BrandbarLogo, BrandbarHomeNav } from './Branding';
 import { useData } from './BrandingContext';
 
-export default function BrandBar({ className, navItems }) {
+export default function BrandBar({ className, navItems, accountMenuItems }) {
   return (
     <nav className={classNames('navbar navbar-expand-lg navbar-light bg-white', className)}>
       <a
@@ -22,7 +22,7 @@ export default function BrandBar({ className, navItems }) {
           {navItems}
         </ul>
         <ul className="navbar-nav">
-          <AccountMenu />
+          <AccountMenu items={accountMenuItems} />
         </ul>
       </div>
     </nav>

--- a/src/account/Menu.js
+++ b/src/account/Menu.js
@@ -9,7 +9,7 @@ import SignedOut from './SignedOut';
 export default function AccountMenu({ items }) {
   const { currentUser } = useContext(CurrentUserContext);
   const [ showSignInModal, setShowSignInModal ] = useState(false);
-  const signedInItems = typeof(items) === 'undefined' ? [] : items.signedIn
+  const signedInItems = (items == null || items.signedIn == null) ? [] : items.signedIn
 
   const modals = (
     <SignInModal

--- a/src/account/Menu.js
+++ b/src/account/Menu.js
@@ -6,9 +6,10 @@ import SignInModal from './SignInModal';
 import SignedIn from './SignedIn';
 import SignedOut from './SignedOut';
 
-export default function AccountMenu() {
+export default function AccountMenu({ items }) {
   const { currentUser } = useContext(CurrentUserContext);
   const [ showSignInModal, setShowSignInModal ] = useState(false);
+  const signedInItems = typeof(items) === 'undefined' ? [] : items.signedIn
 
   const modals = (
     <SignInModal
@@ -20,7 +21,7 @@ export default function AccountMenu() {
   if (currentUser) {
     return (
       <>
-      <SignedIn currentUser={currentUser} />
+      <SignedIn currentUser={currentUser} items={signedInItems} />
       {modals}
       </>
     );

--- a/src/account/SignedIn.js
+++ b/src/account/SignedIn.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 import jsGravatar from 'js-gravatar';
 import { Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
@@ -56,9 +55,7 @@ function SignedIn({ currentUser, items }) {
         </span>
       </DropdownToggle>
       <DropdownMenu>
-        {
-          signedInLinks.map(link => <RoutedLink key={link.href} {...link} />)
-        }
+        { signedInLinks }
         <DropdownItem
           className="nav nav-link dropdown-item"
           onClick={signOut}
@@ -69,14 +66,6 @@ function SignedIn({ currentUser, items }) {
         </DropdownItem>
       </DropdownMenu>
     </Dropdown>
-  );
-}
-
-function RoutedLink({ href, text }) {
-  return (
-    <Link to={href} className="nav nav-link dropdown-item">
-      {text}
-    </Link>
   );
 }
 

--- a/src/account/SignedIn.js
+++ b/src/account/SignedIn.js
@@ -6,12 +6,11 @@ import { Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap
 import styles from './styles.module.css';
 import { useSignOut } from './actions';
 
-const signedInLinks = [];
-
-function SignedIn({ currentUser }) {
+function SignedIn({ currentUser, items }) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const signOut = useSignOut();
   const toggle = () => setDropdownOpen(prevState => !prevState);
+  const signedInLinks = items;
 
   let avatarUrl = currentUser.avatarUrl;
   if (avatarUrl == null) {

--- a/src/account/SignedIn.js
+++ b/src/account/SignedIn.js
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 import jsGravatar from 'js-gravatar';
 import { Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
@@ -56,7 +57,7 @@ function SignedIn({ currentUser, items }) {
       </DropdownToggle>
       <DropdownMenu>
         {
-          signedInLinks.map(link => <Link key={link.href} {...link} />)
+          signedInLinks.map(link => <RoutedLink key={link.href} {...link} />)
         }
         <DropdownItem
           className="nav nav-link dropdown-item"
@@ -71,14 +72,11 @@ function SignedIn({ currentUser, items }) {
   );
 }
 
-function Link({ href, text }) {
+function RoutedLink({ href, text }) {
   return (
-    <DropdownItem
-      href={href}
-      className="nav nav-link"
-    >
+    <Link to={href} className="nav nav-link dropdown-item">
       {text}
-    </DropdownItem>
+    </Link>
   );
 }
 


### PR DESCRIPTION
This PR introduces a change to the rendering of the `AccountMenu` component. Webapps can now specify custom links to be included in the `AccountMenu` by passing an object specifying key-value pairs for an `href` and the `text` for the link. At the moment, this is only used for when a user is signed in, but the support for adding options to the `SignedOut.js` menu is a simple extension.