### PR TITLE
Add unique 'id' prop to list items in brand bar

### DIFF
--- a/src/BrandBar.js
+++ b/src/BrandBar.js
@@ -63,6 +63,7 @@ function BrandBarItems({ className, activeApp }) {
       const title = app.short_title || app.title;
       return (
         <a
+          key={i}
           className={classNames(`nav-link nav-menu-button white-text`, {'active': title === activeApp})}
           href={app.path}
         >


### PR DESCRIPTION
As title. Browser errors were occurring because the items created by `map` require a unique `id` prop.